### PR TITLE
Update Mkdocs config file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: "Tinyscript - A library for quickly prototyping CLI Python-based tool
 repo_url: https://github.com/dhondta/tinyscript
 site_author: dhondta
 docs_dir: docs
-pages:
+nav:
   - Introduction: index.md
   - Setup: setup.md
   - Internals: internals.md


### PR DESCRIPTION
Mkdocs deprecated the "pages" section in favor of the "nav" section. This seems like a trivial rename.

This change happened at release 1.0 of Mkdocs.

Link to relevant changelog section: https://www.mkdocs.org/about/release-notes/#version-10-2018-08-03

From Mkdocs command line:
WARNING -  Config value: 'pages'. Warning: The 'pages' configuration option has been deprecated and will be removed in a future release of MkDocs. Use 'nav' instead.