### PR TITLE
add perma-link for documentation headers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ extra_javascript:
   - js/collapsible-navbar.js
 use_directory_urls: false
 markdown_extensions:
+  - toc:
+      permalink: true
   - admonition
   - codehilite:
       linenums: true


### PR DESCRIPTION
Adds a clickable anchor link next to each header in the documentation.

This allows for direct-linking to any header within a page for simpler referencing.