### PR TITLE
add failsafe for LOG_FORMAT & LOG_DATE

### DIFF
--- a/tinyscript/loglib.py
+++ b/tinyscript/loglib.py
@@ -101,14 +101,12 @@ def configure_logger(glob, multi_level,
     glob['logger'].setLevel(dl)
     if relative:
         coloredlogs.ColoredFormatter = RelativeTimeColoredFormatter
-
-    fmt = glob.get('LOG_FORMAT', LOG_FORMAT)
-    datefmt = glob.get('DATE_FORMAT', DATE_FORMAT)
-
-    coloredlogs.install(dl,
-                        logger=glob['logger'],
-                        fmt=fmt,
-                        datefmt=datefmt,
-                        milliseconds=glob['TIME_MILLISECONDS'],
-                        syslog=syslog,
-                        stream=logfile)
+    coloredlogs.install(
+        dl,
+        logger=glob['logger'],
+        fmt=glob.get('LOG_FORMAT', LOG_FORMAT),
+        datefmt=glob.get('DATE_FORMAT', DATE_FORMAT),
+        milliseconds=glob.get('TIME_MILLISECONDS', TIME_MILLISECONDS),
+        syslog=syslog,
+        stream=logfile,
+    )

--- a/tinyscript/loglib.py
+++ b/tinyscript/loglib.py
@@ -101,10 +101,14 @@ def configure_logger(glob, multi_level,
     glob['logger'].setLevel(dl)
     if relative:
         coloredlogs.ColoredFormatter = RelativeTimeColoredFormatter
+
+    fmt = glob.get('LOG_FORMAT', LOG_FORMAT)
+    datefmt = glob.get('DATE_FORMAT', DATE_FORMAT)
+
     coloredlogs.install(dl,
                         logger=glob['logger'],
-                        fmt=glob['LOG_FORMAT'],
-                        datefmt=glob['DATE_FORMAT'], 
+                        fmt=fmt,
+                        datefmt=datefmt,
                         milliseconds=glob['TIME_MILLISECONDS'],
                         syslog=syslog,
                         stream=logfile)


### PR DESCRIPTION
Example traceback:
```bash
  ~/test                                                                                                                                                                                                   test-hSdYxfq4    3.8.0    1 
  sploitkit-new test
Traceback (most recent call last):
  File "/home/<user>/.local/share/virtualenvs/test-hSdYxfq4/bin/sploitkit-new", line 8, in <module>
    sys.exit(main())
  File "/home/<user>/.local/share/virtualenvs/test-hSdYxfq4/lib/python3.8/site-packages/sploitkit/utils/new.py", line 126, in main
    initialize(globals(), noargs_action="wizard")
  File "/home/<user>/.local/share/virtualenvs/test-hSdYxfq4/lib/python3.8/site-packages/tinyscript/parser.py", line 293, in initialize
    configure_logger(glob, multi_level_debug,
  File "/home/<user>/.local/share/virtualenvs/test-hSdYxfq4/lib/python3.8/site-packages/tinyscript/loglib.py", line 98, in configure_logger
    formatter = logging.Formatter(glob['LOG_FORMAT'], glob['DATE_FORMAT'])
KeyError: 'LOG_FORMAT'
```